### PR TITLE
Add Trait option to enable strict sqid to ID conversion

### DIFF
--- a/src/Eloquent/Traits/HasSqid.php
+++ b/src/Eloquent/Traits/HasSqid.php
@@ -10,43 +10,43 @@ use Illuminate\Database\Eloquent\Model;
  * @method Model|null findBySqid($sqid)
  * @method Model findBySqidOrFail($sqid)
  */
-trait HasSqid 
+trait HasSqid
 {
-	public static function bootHasSqid()
-	{
-		static::addGlobalScope(new SqidScope);
-	}
+    public static function bootHasSqid()
+    {
+        static::addGlobalScope(new SqidScope);
+    }
 
-	public function sqid(): string|null
-	{
-		return $this->idToSqid($this->getKey());
-	}
+    public function sqid(): string|null
+    {
+        return $this->idToSqid($this->getKey());
+    }
 
-	/**
-	 * Decode the sqid to the id
-	 */
-	public function sqidToId(string $sqid): int|null
-	{
-		return Sqids::connection($this->getSqidsConnection())
+    /**
+     * Decode the sqid to the id
+     */
+    public function sqidToId(string $sqid): int|null
+    {
+        return Sqids::connection($this->getSqidsConnection())
             ->decode($sqid)[0] ?? null;
-	}
+    }
 
-	/**
-	 * Encode an id to its equivalent sqid
-	 */
-	public function idToSqid(int $id): string|null
-	{
-		return Sqids::connection($this->getSqidsConnection())
+    /**
+     * Encode an id to its equivalent sqid
+     */
+    public function idToSqid(int $id): string|null
+    {
+        return Sqids::connection($this->getSqidsConnection())
             ->encode([$id]);
-	}
+    }
 
-	protected function getSqidAttribute()
+    protected function getSqidAttribute()
     {
         return $this->sqid();
     }
 
     public function getSqidsConnection()
-	{
-		return config('sqids.default');
-	}
+    {
+        return config('sqids.default');
+    }
 }

--- a/tests/Factories/ItemWithCustomSqidsConnectionFactory.php
+++ b/tests/Factories/ItemWithCustomSqidsConnectionFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ErikSulymosi\EloquentSqids\Tests\Factories;
+
+use ErikSulymosi\EloquentSqids\Tests\Models\ItemWithCustomSqidsConnection;
+use ErikSulymosi\EloquentSqids\Tests\Models\Vendor;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ItemWithCustomSqidsConnectionFactory extends Factory
+{
+	/**
+     * The name of the factory's corresponding model.
+     *
+     * @var class-string<\Illuminate\Database\Eloquent\Model>
+     */
+    protected $model = ItemWithCustomSqidsConnection::class;
+	
+	/**
+	 * Define the model's default state.
+	 * @return array
+	 */
+	public function definition()
+	{
+		return [
+			'slug' => fake()->unique()->word(),
+			'vendor_id' => fn () => Vendor::factory()->create(),
+		];
+	}
+
+	/**
+	 * Indicate that the item is deleted.
+	 */
+	public function softDeleted(): Factory
+	{
+		return $this->state(fn() => [
+			'deleted_at' => now(),
+		]);
+	}
+}

--- a/tests/HasSqidTest.php
+++ b/tests/HasSqidTest.php
@@ -102,3 +102,19 @@ it('can handle custom sqids connection for model', function ()
 
     $this->assertEquals('bdcdecabad', (new ItemWithCustomSqidsConnection)->idToSqid(1));
 });
+
+it('allows for strict sqid to ID conversion', function ()
+{
+    $item = ItemWithCustomSqidsConnection::factory()->create();
+
+    $this->assertEquals('bdcdecabad', $item->sqid());
+
+    $this->assertTrue(ItemwithCustomSqidsConnection::findBySqid('bdcdecabad')->is($item));
+    $this->assertTrue(ItemwithCustomSqidsConnection::findBySqid('bd')->is($item));
+
+    ItemWithCustomSqidsConnection::setStrictSqids();
+
+    $this->assertTrue(ItemwithCustomSqidsConnection::findBySqid('bdcdecabad')->is($item));
+    $this->assertNull(ItemwithCustomSqidsConnection::findBySqid('bd'));
+
+});

--- a/tests/Models/ItemWithCustomSqidsConnection.php
+++ b/tests/Models/ItemWithCustomSqidsConnection.php
@@ -8,15 +8,15 @@ use Illuminate\Database\Eloquent\Model;
 
 class ItemWithCustomSqidsConnection extends Model
 {
-	use HasSqid;
-	use SqidRouting;
+    use HasSqid;
+    use SqidRouting;
 
-	protected $guarded = [];
+    protected $guarded = [];
 
-	protected $table = 'items';
+    protected $table = 'items';
 
-	public function getSqidsConnection()
-	{
-		return 'custom';
-	}
+    public function getSqidsConnection()
+    {
+        return 'custom';
+    }
 }

--- a/tests/Models/ItemWithCustomSqidsConnection.php
+++ b/tests/Models/ItemWithCustomSqidsConnection.php
@@ -4,12 +4,15 @@ namespace ErikSulymosi\EloquentSqids\Tests\Models;
 
 use ErikSulymosi\EloquentSqids\Eloquent\Traits\HasSqid;
 use ErikSulymosi\EloquentSqids\Eloquent\Traits\SqidRouting;
+use ErikSulymosi\EloquentSqids\Tests\Factories\ItemWithCustomSqidsConnectionFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class ItemWithCustomSqidsConnection extends Model
 {
     use HasSqid;
     use SqidRouting;
+    use HasFactory;
 
     protected $guarded = [];
 

--- a/tests/Models/ItemWithCustomSqidsConnection.php
+++ b/tests/Models/ItemWithCustomSqidsConnection.php
@@ -19,4 +19,9 @@ class ItemWithCustomSqidsConnection extends Model
     {
         return 'custom';
     }
+
+    protected static function newFactory()
+    {
+        return new ItemWithCustomSqidsConnectionFactory();
+    }
 }


### PR DESCRIPTION
While using this package to use Sqid IDs in URLS I noticed that especially with lower primary keys and long alphabets, the sqid in the URL has very few characters. This makes randomly guessing a Sqid pretty easy (and then reverse engineer the used alphabet).

Even when setting a minimum length, of for example 10, it adds padding of gibberish chars at the end it only uses the first couple chars to decode the ID. When testing the URL, I could remove 8 of the 10 chars and still load the model. And in theory, according to the Sqid documentation, multiple sqids could result in the same decoded int. 

Additionally, when decoding sqid to int, we are only using the first item from the decoded array, so when provided a random sqid that decodes to `[3,6,9]`, the given sqid should be invalid, but it now allows this, and returns model with primary key of 3.

To prevent this from happening I've added a static $useStrictSqids boolean to the HasSqid Trait, and the accompanying static usesStrictSqids() method to enabling strict sqid conversion.

When setting this static variable to `true` (at runtime, or in the AppServiceProvider),  the `sqidToId($sqid)` method it will check if the given $sqid string corresponds to the actual sqid string when encoding `[$primaryKey]`. This will take the minimum length into account and will prevent all the above mentioned sqid strings from being valid.

Let me know what you think of this addition. I you like it and want to merge it, let me know and we can work on updating the Readme.md.

